### PR TITLE
Add Gemini API option for AI summary settings

### DIFF
--- a/lib/view_models/ai_settings_view_model.dart
+++ b/lib/view_models/ai_settings_view_model.dart
@@ -6,31 +6,77 @@ const _apiKeyPreferenceKey = 'ai_api_key';
 const _baseUrlPreferenceKey = 'ai_base_url';
 const _modelPreferenceKey = 'ai_model';
 const _endpointPreferenceKey = 'ai_endpoint_path';
+const _providerPreferenceKey = 'ai_provider';
+
+const _openAiDefaultBaseUrl = 'https://api.openai.com/v1';
+const _openAiDefaultModel = 'gpt-4o-mini';
+const _openAiDefaultEndpoint = '/chat/completions';
+
+const _geminiDefaultBaseUrl = 'https://generativelanguage.googleapis.com';
+const _geminiDefaultModel = 'gemini-1.5-flash';
+const _geminiDefaultEndpoint =
+    '/v1beta/models/gemini-1.5-flash:generateContent';
+
+enum AiProvider { openAi, gemini }
+
+String _defaultBaseUrlFor(AiProvider provider) {
+  switch (provider) {
+    case AiProvider.openAi:
+      return _openAiDefaultBaseUrl;
+    case AiProvider.gemini:
+      return _geminiDefaultBaseUrl;
+  }
+}
+
+String _defaultModelFor(AiProvider provider) {
+  switch (provider) {
+    case AiProvider.openAi:
+      return _openAiDefaultModel;
+    case AiProvider.gemini:
+      return _geminiDefaultModel;
+  }
+}
+
+String _defaultEndpointFor(AiProvider provider) {
+  switch (provider) {
+    case AiProvider.openAi:
+      return _openAiDefaultEndpoint;
+    case AiProvider.gemini:
+      return _geminiDefaultEndpoint;
+  }
+}
 
 @immutable
 class AiSettings {
   const AiSettings({
+    this.provider = AiProvider.openAi,
     this.apiKey = '',
-    this.baseUrl = 'https://api.openai.com/v1',
-    this.model = 'gpt-4o-mini',
-    this.endpointPath = '/chat/completions',
+    this.baseUrl = _openAiDefaultBaseUrl,
+    this.model = _openAiDefaultModel,
+    this.endpointPath = _openAiDefaultEndpoint,
   });
 
+  final AiProvider provider;
   final String apiKey;
   final String baseUrl;
   final String model;
   final String endpointPath;
 
   bool get isConfigured =>
-      apiKey.trim().isNotEmpty && baseUrl.trim().isNotEmpty && model.trim().isNotEmpty;
+      apiKey.trim().isNotEmpty &&
+      baseUrl.trim().isNotEmpty &&
+      model.trim().isNotEmpty &&
+      endpointPath.trim().isNotEmpty;
 
   AiSettings copyWith({
+    AiProvider? provider,
     String? apiKey,
     String? baseUrl,
     String? model,
     String? endpointPath,
   }) {
     return AiSettings(
+      provider: provider ?? this.provider,
       apiKey: apiKey ?? this.apiKey,
       baseUrl: baseUrl ?? this.baseUrl,
       model: model ?? this.model,
@@ -46,14 +92,34 @@ class AiSettingsNotifier extends StateNotifier<AiSettings> {
 
   Future<void> _loadSettings() async {
     final prefs = await SharedPreferences.getInstance();
+    final providerString = prefs.getString(_providerPreferenceKey);
+    final provider = _parseProvider(providerString) ?? state.provider;
     final storedSettings = state.copyWith(
+      provider: provider,
       apiKey: prefs.getString(_apiKeyPreferenceKey) ?? state.apiKey,
-      baseUrl: prefs.getString(_baseUrlPreferenceKey) ?? state.baseUrl,
-      model: prefs.getString(_modelPreferenceKey) ?? state.model,
-      endpointPath:
-          prefs.getString(_endpointPreferenceKey) ?? state.endpointPath,
+      baseUrl: prefs.getString(_baseUrlPreferenceKey) ??
+          _defaultBaseUrlFor(provider),
+      model: prefs.getString(_modelPreferenceKey) ??
+          _defaultModelFor(provider),
+      endpointPath: prefs.getString(_endpointPreferenceKey) ??
+          _defaultEndpointFor(provider),
     );
     state = storedSettings;
+  }
+
+  Future<void> updateProvider(AiProvider provider) async {
+    final newState = state.copyWith(
+      provider: provider,
+      baseUrl: _defaultBaseUrlFor(provider),
+      model: _defaultModelFor(provider),
+      endpointPath: _defaultEndpointFor(provider),
+    );
+    state = newState;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_providerPreferenceKey, provider.name);
+    await prefs.setString(_baseUrlPreferenceKey, newState.baseUrl);
+    await prefs.setString(_modelPreferenceKey, newState.model);
+    await prefs.setString(_endpointPreferenceKey, newState.endpointPath);
   }
 
   Future<void> updateApiKey(String apiKey) async {
@@ -65,7 +131,7 @@ class AiSettingsNotifier extends StateNotifier<AiSettings> {
 
   Future<void> updateBaseUrl(String baseUrl) async {
     final sanitized = baseUrl.trim().isEmpty
-        ? const AiSettings().baseUrl
+        ? _defaultBaseUrlFor(state.provider)
         : baseUrl.trim();
     final newState = state.copyWith(baseUrl: sanitized);
     state = newState;
@@ -74,7 +140,8 @@ class AiSettingsNotifier extends StateNotifier<AiSettings> {
   }
 
   Future<void> updateModel(String model) async {
-    final sanitized = model.trim().isEmpty ? state.model : model.trim();
+    final sanitized =
+        model.trim().isEmpty ? _defaultModelFor(state.provider) : model.trim();
     final newState = state.copyWith(model: sanitized);
     state = newState;
     final prefs = await SharedPreferences.getInstance();
@@ -83,7 +150,7 @@ class AiSettingsNotifier extends StateNotifier<AiSettings> {
 
   Future<void> updateEndpointPath(String endpointPath) async {
     final sanitized = endpointPath.trim().isEmpty
-        ? const AiSettings().endpointPath
+        ? _defaultEndpointFor(state.provider)
         : endpointPath.trim();
     final normalized = sanitized.startsWith('/') ? sanitized : '/$sanitized';
     final newState = state.copyWith(endpointPath: normalized);
@@ -91,6 +158,16 @@ class AiSettingsNotifier extends StateNotifier<AiSettings> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_endpointPreferenceKey, newState.endpointPath);
   }
+}
+
+AiProvider? _parseProvider(String? providerString) {
+  if (providerString == null || providerString.isEmpty) {
+    return null;
+  }
+  return AiProvider.values.firstWhere(
+    (provider) => provider.name == providerString,
+    orElse: () => AiProvider.openAi,
+  );
 }
 
 final aiSettingsProvider =

--- a/lib/views/url_list_view.dart
+++ b/lib/views/url_list_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:url_manager/database.dart';
 import 'package:url_manager/view_models/url_view_model.dart';
 import 'package:url_manager/view_models/url_summary_view_model.dart';
+import 'package:url_manager/views/ai_settings_view.dart';
 import 'package:url_manager/views/url_add_view.dart';
 import 'package:url_manager/views/url_summary_view.dart';
 
@@ -25,6 +26,18 @@ class UrlListView extends ConsumerWidget {
                   title: const Text('URLs'),
                   floating: true,
                   expandedHeight: 30.0.h,
+                  actions: [
+                    IconButton(
+                      icon: const Icon(Icons.settings_outlined),
+                      onPressed: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => const AiSettingsView(),
+                          ),
+                        );
+                      },
+                    ),
+                  ],
                 ),
                 SliverList(
                   delegate: SliverChildBuilderDelegate(

--- a/lib/views/url_summary_view.dart
+++ b/lib/views/url_summary_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:url_manager/view_models/url_summary_view_model.dart';
-import 'package:url_manager/views/ai_settings_view.dart';
 
 class UrlSummary extends ConsumerWidget {
   const UrlSummary({
@@ -32,16 +31,6 @@ class UrlSummary extends ConsumerWidget {
                 },
                 icon: const Icon(Icons.replay_outlined),
               ),
-              IconButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => const AiSettingsView(),
-                    ),
-                  );
-                },
-                icon: const Icon(Icons.settings_outlined),
-              )
             ],
           ),
           body: Scrollbar(

--- a/lib/views/url_summary_view.dart
+++ b/lib/views/url_summary_view.dart
@@ -1,10 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:url_manager/view_models/url_summary_view_model.dart';
 
-class UrlSummary extends ConsumerWidget {
+class UrlSummary extends ConsumerStatefulWidget {
   const UrlSummary({
     super.key,
     required this.summaryRequest,
@@ -13,8 +15,45 @@ class UrlSummary extends ConsumerWidget {
   final SummaryRequest summaryRequest;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final summaryAsync = ref.watch(urlSummaryProvider(summaryRequest));
+  ConsumerState<UrlSummary> createState() => _UrlSummaryState();
+}
+
+class _UrlSummaryState extends ConsumerState<UrlSummary> {
+  @override
+  void initState() {
+    super.initState();
+    _ensureSummaryLoaded();
+  }
+
+  @override
+  void didUpdateWidget(covariant UrlSummary oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.summaryRequest != widget.summaryRequest) {
+      _ensureSummaryLoaded(forceRefresh: false);
+    }
+  }
+
+  void _ensureSummaryLoaded({bool forceRefresh = false}) {
+    final cache = ref.read(summaryCacheProvider);
+    final existing = cache[widget.summaryRequest];
+    if (existing == null || forceRefresh) {
+      Future.microtask(() {
+        ref
+            .read(summaryCacheProvider.notifier)
+            .loadSummary(widget.summaryRequest, forceRefresh: forceRefresh);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final summaryAsync = ref.watch(
+      summaryCacheProvider.select(
+        (cache) => cache[widget.summaryRequest],
+      ),
+    );
+
+    final value = summaryAsync ?? const AsyncValue<String>.loading();
 
     return ScreenUtilInit(
       designSize: const Size(926, 428),
@@ -27,7 +66,7 @@ class UrlSummary extends ConsumerWidget {
             actions: [
               IconButton(
                 onPressed: () {
-                  ref.refresh(urlSummaryProvider(summaryRequest));
+                  _ensureSummaryLoaded(forceRefresh: true);
                 },
                 icon: const Icon(Icons.replay_outlined),
               ),
@@ -36,7 +75,7 @@ class UrlSummary extends ConsumerWidget {
           body: Scrollbar(
             child: Padding(
               padding: EdgeInsets.all(16.w),
-              child: summaryAsync.when(
+              child: value.when(
                 data: (summary) {
                   final markdown = summary.trim().isEmpty
                       ? '要約結果が空でした。設定やAPIレスポンスを確認してください。'


### PR DESCRIPTION
## Summary
- introduce an AI provider setting with persisted defaults for both OpenAI-compatible and Gemini endpoints
- update the AI settings view to offer provider selection, context-aware hints, and controller syncing with saved values
- extend summary generation logic to call Gemini's generateContent API when that provider is selected

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d108603898832d9b174fb134c03218