### PR TITLE
設定画面に永続化する表示設定を追加

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
 
+// アプリ起動時に読み込む永続設定を利用してテーマを切り替えるためにViewModelを参照する。
+import 'view_models/settings_preferences_view_model.dart';
 import 'views/url_list_view.dart';
 
+// アプリケーションエントリーポイント。初期化処理を行ってからRiverpodのProviderScopeでラップする。
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeDateFormatting('ja_JP');
@@ -15,32 +18,44 @@ Future<void> main() async {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
-    final baseScheme = ColorScheme.fromSeed(
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Riverpodで管理している表示設定を監視し、ダークテーマ切り替えに反映する。
+    final settings = ref.watch(settingsPreferencesProvider);
+
+    // 既存のライトテーマ。Seed ColorからColorSchemeを構築してマテリアル3に適用。
+    final lightScheme = ColorScheme.fromSeed(
       seedColor: const Color(0xFF1A73E8),
       brightness: Brightness.light,
+    );
+
+    // ダークテーマ用のColorScheme。UI全体のコントラストを確保する。
+    final darkScheme = ColorScheme.fromSeed(
+      seedColor: const Color(0xFF0B57D0),
+      brightness: Brightness.dark,
     );
 
     return MaterialApp(
       title: 'URL Manager',
       debugShowCheckedModeBanner: false,
+      // SharedPreferencesに保存された設定値からダークテーマを強制するか判定する。
+      themeMode: settings.enableDarkTheme ? ThemeMode.dark : ThemeMode.system,
       theme: ThemeData(
         useMaterial3: true,
-        colorScheme: baseScheme,
-        scaffoldBackgroundColor: baseScheme.surface,
+        colorScheme: lightScheme,
+        scaffoldBackgroundColor: lightScheme.surface,
         appBarTheme: const AppBarTheme(
           centerTitle: false,
         ),
         snackBarTheme: SnackBarThemeData(
           behavior: SnackBarBehavior.floating,
-          backgroundColor: baseScheme.inverseSurface,
-          contentTextStyle: TextStyle(color: baseScheme.onInverseSurface),
+          backgroundColor: lightScheme.inverseSurface,
+          contentTextStyle: TextStyle(color: lightScheme.onInverseSurface),
         ),
         inputDecorationTheme: InputDecorationTheme(
           filled: true,
-          fillColor: baseScheme.surfaceVariant.withOpacity(0.4),
+          fillColor: lightScheme.surfaceVariant.withOpacity(0.4),
           border: OutlineInputBorder(
             borderRadius: BorderRadius.circular(16),
             borderSide: BorderSide.none,
@@ -50,7 +65,34 @@ class MyApp extends StatelessWidget {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
           ),
-          side: BorderSide(color: baseScheme.outlineVariant),
+          side: BorderSide(color: lightScheme.outlineVariant),
+        ),
+      ),
+      darkTheme: ThemeData(
+        useMaterial3: true,
+        colorScheme: darkScheme,
+        scaffoldBackgroundColor: darkScheme.surface,
+        appBarTheme: const AppBarTheme(
+          centerTitle: false,
+        ),
+        snackBarTheme: SnackBarThemeData(
+          behavior: SnackBarBehavior.floating,
+          backgroundColor: darkScheme.inverseSurface,
+          contentTextStyle: TextStyle(color: darkScheme.onInverseSurface),
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          filled: true,
+          fillColor: darkScheme.surfaceVariant.withOpacity(0.4),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
+        ),
+        chipTheme: ChipThemeData(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+          side: BorderSide(color: darkScheme.outlineVariant),
         ),
       ),
       home: const UrlListView(),

--- a/lib/view_models/settings_preferences_view_model.dart
+++ b/lib/view_models/settings_preferences_view_model.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// SharedPreferences に保存するキー定義。用途をコメントで明示して管理する。
+const _wifiOnlySummaryKey = 'settings_wifi_only_summary'; // AI要約をWi-Fi接続時のみに制限するかどうか。
+const _preferDynamicTypeKey = 'settings_prefer_dynamic_type'; // OSのDynamic Type設定に追従するかどうか。
+const _darkThemeKey = 'settings_enable_dark_theme'; // アプリ全体でダークテーマを有効化するかどうか。
+const _startTabKey = 'settings_start_tab'; // アプリ起動時に最初に表示するタブの識別子。
+
+/// アプリ全体の表示や操作に関する永続設定をまとめたステート。
+@immutable
+class SettingsPreferencesState {
+  const SettingsPreferencesState({
+    this.wifiOnlySummary = false,
+    this.preferDynamicType = true,
+    this.enableDarkTheme = false,
+    this.startTab = StartTab.inbox,
+  });
+
+  /// AI要約をWi-Fi接続時に限定するためのフラグ。
+  final bool wifiOnlySummary;
+
+  /// OSのDynamic Type（文字サイズ）設定を優先するかどうかのフラグ。
+  final bool preferDynamicType;
+
+  /// アプリ全体でダークテーマを使用するかどうかのフラグ。
+  final bool enableDarkTheme;
+
+  /// アプリを起動した際に最初に開くタブを示す設定値。
+  final StartTab startTab;
+
+  SettingsPreferencesState copyWith({
+    bool? wifiOnlySummary,
+    bool? preferDynamicType,
+    bool? enableDarkTheme,
+    StartTab? startTab,
+  }) {
+    return SettingsPreferencesState(
+      wifiOnlySummary: wifiOnlySummary ?? this.wifiOnlySummary,
+      preferDynamicType: preferDynamicType ?? this.preferDynamicType,
+      enableDarkTheme: enableDarkTheme ?? this.enableDarkTheme,
+      startTab: startTab ?? this.startTab,
+    );
+  }
+}
+
+/// 起動時に表示するタブを表現する列挙型。ユーザーが頻繁に利用する画面を選択できるようにする。
+enum StartTab {
+  inbox, // 受信/最新タブ。
+  favorites, // お気に入りタブ。
+  tags, // タグ別一覧タブ。
+}
+
+/// UIで表示名を扱いやすくするための拡張。列挙値ごとにラベルを返す。
+extension StartTabLabel on StartTab {
+  String get label {
+    switch (this) {
+      case StartTab.inbox:
+        return '最新フィード';
+      case StartTab.favorites:
+        return 'お気に入り';
+      case StartTab.tags:
+        return 'タグ';
+    }
+  }
+}
+
+/// SharedPreferences と連携しながら [SettingsPreferencesState] を管理する StateNotifier。
+class SettingsPreferencesNotifier
+    extends StateNotifier<SettingsPreferencesState> {
+  SettingsPreferencesNotifier() : super(const SettingsPreferencesState()) {
+    _loadPreferences();
+  }
+
+  /// 保存済みの設定を非同期に読み出し、StateNotifier に反映する。
+  Future<void> _loadPreferences() async {
+    final prefs = await SharedPreferences.getInstance();
+    final storedStartTab = _parseStartTab(prefs.getString(_startTabKey));
+    state = state.copyWith(
+      wifiOnlySummary: prefs.getBool(_wifiOnlySummaryKey) ?? state.wifiOnlySummary,
+      preferDynamicType:
+          prefs.getBool(_preferDynamicTypeKey) ?? state.preferDynamicType,
+      enableDarkTheme: prefs.getBool(_darkThemeKey) ?? state.enableDarkTheme,
+      startTab: storedStartTab ?? state.startTab,
+    );
+  }
+
+  /// Wi-Fi制限設定をトグルし、新しい状態を返す。
+  Future<bool> toggleWifiOnlySummary() async {
+    final newValue = !state.wifiOnlySummary;
+    state = state.copyWith(wifiOnlySummary: newValue);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_wifiOnlySummaryKey, newValue);
+    return newValue;
+  }
+
+  /// Dynamic Type優先設定をトグルし、新しい状態を返す。
+  Future<bool> togglePreferDynamicType() async {
+    final newValue = !state.preferDynamicType;
+    state = state.copyWith(preferDynamicType: newValue);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_preferDynamicTypeKey, newValue);
+    return newValue;
+  }
+
+  /// ダークテーマ設定をトグルし、新しい状態を返す。
+  Future<bool> toggleDarkTheme() async {
+    final newValue = !state.enableDarkTheme;
+    state = state.copyWith(enableDarkTheme: newValue);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_darkThemeKey, newValue);
+    return newValue;
+  }
+
+  /// 起動時に表示するタブを更新し、永続化する。
+  Future<void> updateStartTab(StartTab tab) async {
+    state = state.copyWith(startTab: tab);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_startTabKey, tab.name);
+  }
+
+  StartTab? _parseStartTab(String? raw) {
+    if (raw == null) {
+      return null;
+    }
+    return StartTab.values.firstWhere(
+      (tab) => tab.name == raw,
+      orElse: () => StartTab.inbox,
+    );
+  }
+}
+
+/// 設定カードから利用する StateNotifierProvider。UI が状態を監視できるよう公開する。
+final settingsPreferencesProvider =
+    StateNotifierProvider<SettingsPreferencesNotifier, SettingsPreferencesState>(
+  (ref) => SettingsPreferencesNotifier(),
+);

--- a/lib/view_models/settings_preferences_view_model.dart
+++ b/lib/view_models/settings_preferences_view_model.dart
@@ -24,7 +24,7 @@ class SettingsPreferencesState {
   /// OSのDynamic Type（文字サイズ）設定を優先するかどうかのフラグ。
   final bool preferDynamicType;
 
-  /// アプリ全体でダークテーマを使用するかどうかのフラグ。
+  /// true の場合は常にダークテーマを使用し、false の場合はシステム設定に従うフラグ。
   final bool enableDarkTheme;
 
   /// アプリを起動した際に最初に開くタブを示す設定値。

--- a/lib/views/settings_root_view.dart
+++ b/lib/views/settings_root_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_manager/view_models/settings_preferences_view_model.dart';
 import 'package:url_manager/views/ai_settings_view.dart';
 
 class SettingsRootView extends ConsumerWidget {
@@ -8,6 +9,17 @@ class SettingsRootView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    // アプリ全体の操作系設定をRiverpod経由で監視し、UIのトグルと同期させる。
+    final settings = ref.watch(settingsPreferencesProvider);
+
+    // 設定が変更された際に即座にフィードバックできるようSnackBar表示用の関数を用意。
+    void showPreferenceSavedMessage(String message) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(content: Text(message)),
+        );
+    }
     return SafeArea(
       child: ListView(
         padding: const EdgeInsets.fromLTRB(16, 24, 16, 120),
@@ -40,16 +52,91 @@ class SettingsRootView extends ConsumerWidget {
                 ),
                 const Divider(height: 1),
                 SwitchListTile.adaptive(
-                  value: true,
-                  onChanged: (_) {},
+                  // Wi-Fi接続時のみAI要約を実行する設定。StateNotifierの値と同期。
+                  value: settings.wifiOnlySummary,
+                  onChanged: (_) async {
+                    final enabled = await ref
+                        .read(settingsPreferencesProvider.notifier)
+                        .toggleWifiOnlySummary();
+                    showPreferenceSavedMessage(
+                      enabled
+                          ? 'Wi-Fi接続時のみAI要約を実行します'
+                          : 'モバイル回線でもAI要約を実行します',
+                    );
+                  },
                   title: const Text('Wi-Fi時のみ要約リクエスト'),
-                  subtitle: const Text('通信量を抑えたいときに有効化'),
+                  subtitle: Text(
+                    settings.wifiOnlySummary
+                        ? '通信量を抑えるためWi-Fi接続時のみAI要約を実行'
+                        : 'モバイル回線でもAI要約を実行して素早く要約取得',
+                  ),
                 ),
                 SwitchListTile.adaptive(
-                  value: true,
-                  onChanged: (_) {},
+                  // Dynamic Type優先設定。アクセシビリティ対応のためのトグル。
+                  value: settings.preferDynamicType,
+                  onChanged: (_) async {
+                    final enabled = await ref
+                        .read(settingsPreferencesProvider.notifier)
+                        .togglePreferDynamicType();
+                    showPreferenceSavedMessage(
+                      enabled
+                          ? 'OSの文字サイズ設定に合わせて表示します'
+                          : 'アプリ既定の文字サイズで表示します',
+                    );
+                  },
                   title: const Text('Dynamic Typeを優先'),
-                  subtitle: const Text('OSの文字サイズ設定に追従'),
+                  subtitle: Text(
+                    settings.preferDynamicType
+                        ? 'OSの文字サイズ設定に追従して可読性を確保'
+                        : 'アプリ内の固定フォントサイズを使用',
+                  ),
+                ),
+                SwitchListTile.adaptive(
+                  // アプリ全体のダークテーマ有効化設定。
+                  value: settings.enableDarkTheme,
+                  onChanged: (_) async {
+                    final enabled = await ref
+                        .read(settingsPreferencesProvider.notifier)
+                        .toggleDarkTheme();
+                    showPreferenceSavedMessage(
+                      enabled
+                          ? '常にダークテーマで表示します'
+                          : 'システム設定に合わせたテーマで表示します',
+                    );
+                  },
+                  title: const Text('ダークテーマを常に使用'),
+                  subtitle: Text(
+                    settings.enableDarkTheme
+                        ? '夜間や暗所で見やすいダークテーマを固定'
+                        : 'システムテーマに追従して表示を自動調整',
+                  ),
+                ),
+                ListTile(
+                  // 起動時に開くタブを選択する設定。DropdownでRiverpod状態と同期。
+                  title: const Text('起動時の表示タブ'),
+                  subtitle: Text('現在: ${settings.startTab.label}'),
+                  trailing: DropdownButton<StartTab>(
+                    value: settings.startTab,
+                    onChanged: (value) async {
+                      if (value == null) {
+                        return;
+                      }
+                      await ref
+                          .read(settingsPreferencesProvider.notifier)
+                          .updateStartTab(value);
+                      showPreferenceSavedMessage(
+                        '起動時に「${value.label}」タブを表示します',
+                      );
+                    },
+                    items: StartTab.values
+                        .map(
+                          (tab) => DropdownMenuItem<StartTab>(
+                            value: tab,
+                            child: Text(tab.label),
+                          ),
+                        )
+                        .toList(),
+                  ),
                 ),
               ],
             ),


### PR DESCRIPTION
## 概要
- Wi-Fi制限やDynamic Type優先、ダークテーマ、起動タブを管理するSharedPreferences連携のStateNotifierを新規作成
- 設定トップカードのスイッチとドロップダウンをStateNotifierと連動させ、操作ごとにSnackBarで保存結果を通知


------
https://chatgpt.com/codex/tasks/task_e_68d2c13b1e94832da1e8e2fbb7730078